### PR TITLE
PHP 7.2 deprecation fixes

### DIFF
--- a/classes/ezooconverter.php
+++ b/classes/ezooconverter.php
@@ -42,7 +42,7 @@ class eZOOConverter
     /*!
      Constructor
     */
-    function eZOOConverter()
+    function __construct()
     {
     }
 

--- a/classes/ezoogenerator.php
+++ b/classes/ezoogenerator.php
@@ -51,7 +51,7 @@ class eZOOGenerator
     /*!
      Constructor
     */
-    function eZOOGenerator()
+    function __construct()
     {
     }
 

--- a/classes/ezooimport.php
+++ b/classes/ezooimport.php
@@ -71,7 +71,7 @@ class eZOOImport
     /*!
      Constructor
     */
-    function eZOOImport()
+    function __construct()
     {
         $this->ERROR['number'] = 0;
         $this->ERROR['value'] = '';

--- a/uploadhandlers/ezopenofficeuploadhandler.php
+++ b/uploadhandlers/ezopenofficeuploadhandler.php
@@ -39,9 +39,9 @@
 
 class eZOpenofficeUploadHandler extends eZContentUploadHandler
 {
-    function eZOpenofficeUploadHandler()
+    function __construct()
     {
-        $this->eZContentUploadHandler( 'OOo file handling', 'openoffice' );
+        parent::__construct( 'OOo file handling', 'openoffice' );
     }
 
     /*!


### PR DESCRIPTION
fixes:

```
 PHP | File:Line                                                                                          |             Type | Issue
 7.0 | /classes/ezooconverter.php:45                                                                      | method_name      | Method name eZOOConverter:eZOOConverter (@php4_constructors) is deprecated. 
 7.0 | /classes/ezoogenerator.php:54                                                                      | method_name      | Method name eZOOGenerator:eZOOGenerator (@php4_constructors) is deprecated. 
 7.0 | /classes/ezooimport.php:74                                                                         | method_name      | Method name eZOOImport:eZOOImport (@php4_constructors) is deprecated. 
 7.0 | /uploadhandlers/ezopenofficeuploadhandler.php:42                                                   | method_name      | Method name eZOpenofficeUploadHandler:eZOpenofficeUploadHandler (@php4_constructors) is deprecated. 
```