### PR TITLE
EZP-27804: Constructor refactoring follow-up

### DIFF
--- a/uploadhandlers/ezopenofficeuploadhandler.php
+++ b/uploadhandlers/ezopenofficeuploadhandler.php
@@ -39,9 +39,9 @@
 
 class eZOpenofficeUploadHandler extends eZContentUploadHandler
 {
-    function eZOpenofficeUploadHandler()
+    function __construct()
     {
-        $this->eZContentUploadHandler( 'OOo file handling', 'openoffice' );
+        parent::__construct( 'OOo file handling', 'openoffice' );
     }
 
     /*!


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-27804
> https://github.com/ezsystems/ezpublish-legacy/pull/1233

EZP-27804 introduced refactoring of every constructors in legacy kernel.

This class was omitted, which causes errors with multi upload:

```
[ fév 04 2019 14:13:52 ] Unexpected error, the message was : Call to undefined method eZOpenofficeUploadHandler::eZContentUploadHandler() in /Users/lolautruche/workspace/foo/ezpublish_legacy/extension/ezodf/uploadhandlers/ezopenofficeuploadhandler.php on line 44
```

This PR fixes the issue.